### PR TITLE
PMTMapping functions added. Example provided.

### DIFF
--- a/analysis_tools/wcsim_wcte_coordinate_transformation.py
+++ b/analysis_tools/wcsim_wcte_coordinate_transformation.py
@@ -2,18 +2,27 @@ import numpy as np
 
 class coordinateTransform:
     def __init__(self):
-        # Define the offset
+        """
+        Define the offset
+        """
+        
         self.vertical_offset = 424.7625 #mm
 
+    # ───────────────────────────── #
+    # 1. WCSim → WCTE               #
+    # ───────────────────────────── #
+    
     def wcsim_to_wcte(self, wcsim_coords, offset=None):
-        # Transform a set of WCSim coordinates into a set of WCTE coordinates
-        # WCSim coordinates MUST be given following the convention:
-        # X is the horizontal axis perpendicular to the beam direction
-        # Y is the vertical axis, where +Y means upwards and -Y downwards
-        # Z is the horizontal axis parallel to the beam direction
+        """
+        Transform a set of WCSim coordinates into a set of WCTE coordinates
+        WCSim coordinates MUST be given following the convention:          
+        X is the horizontal axis perpendicular to the beam direction       
+        Y is the vertical axis, where +Y means upwards and -Y downwards    
+        Z is the horizontal axis parallel to the beam direction            
+                                                                        
+        Use a list or an Array for the WCSim coords                        
+        """
 
-        # Use a list or an Array for the WCSim coords
-        
         if offset is None:
             offset = self.vertical_offset
             
@@ -29,15 +38,21 @@ class coordinateTransform:
 
         return wcte_coords
     
+    # ───────────────────────────── #
+    # 2. WCTE → WCSim               #
+    # ───────────────────────────── #
+
     def wcte_to_wcsim(self, wcte_coords, offset=None):
-        # Transform a set of WCTE coordinates into a set of WCSim coordinates
-        # WCTE coordinates MUST be given following the convention:
-        # X is the horizontal axis perpendicular to the beam direction
-        # Y is the vertical axis, where +Y means upwards and -Y downwards
-        # Z is the horizontal axis parallel to the beam direction
-
-        # Use a list or an Array for the WCTE coords
-
+        """
+        Transform a set of WCTE coordinates into a set of WCSim coordinates
+        WCTE coordinates MUST be given following the convention:           
+        X is the horizontal axis perpendicular to the beam direction       
+        Y is the vertical axis, where +Y means upwards and -Y downwards    
+        Z is the horizontal axis parallel to the beam direction            
+                                                                        
+        Use a list or an Array for the WCTE coords                         
+        
+        """
         if offset is None:
             offset = self.vertical_offset
             
@@ -53,4 +68,86 @@ class coordinateTransform:
 
         return wcsim_coords
 
+class PMTMapping:
+    def __init__(self, geo_path):
+        """
+        geo_path: path al archivo de geometría (WCSim)
+        """
+        self.tube_to_slotpos = {}
+        self.slotpos_to_tube = {}
 
+        self._load_mapping(geo_path)
+
+    # ───────────────────────────── #
+    # LOAD MAPPING                  #
+    # ───────────────────────────── #
+    
+    def _load_mapping(self, geo_path):
+        data = np.loadtxt(geo_path, skiprows=5, usecols=(0, 1, 2), dtype=int)
+
+        for tube_no, slot, pos in data:
+            pos0 = pos - 1  # convert to 0-index
+            
+            self.tube_to_slotpos[tube_no] = (slot, pos0)
+            self.slotpos_to_tube[(slot, pos0)] = tube_no
+
+    # ───────────────────────────── #
+    # 1. slot, pos → pmt_id (WCTE)  #
+    # ───────────────────────────── #
+    
+    def slotpos_to_pmt_id(self, slot, pos):
+        """
+        Returns pmt_id in WCTE convention
+        """
+        return slot * 19 + pos
+
+    # ───────────────────────────── #
+    # 2. WCTE → WCSim               #
+    # ───────────────────────────── #
+    
+    def wcte_to_wcsim(self, pmt_id):
+        """
+        pmt_id (WCTE) → tube_no (WCSim)
+        """
+        slot = pmt_id // 19
+        pos  = pmt_id % 19
+
+        key = (slot, pos)
+        if key not in self.slotpos_to_tube:
+            raise ValueError(f"Invalid (slot, pos): {key}")
+
+        tube_no = self.slotpos_to_tube[key]
+
+        return tube_no - 1  # WCSim uses 0-index
+
+    # ───────────────────────────── #
+    # 3. WCSim → WCTE               #
+    # ───────────────────────────── #
+    
+    def wcsim_to_wcte(self, tube_no):
+        """
+        tube_no (WCSim) → pmt_id (WCTE)
+        """
+        tube_key = int(tube_no) + 1  # pass to internal convention
+
+        if tube_key not in self.tube_to_slotpos:
+            raise ValueError(f"Invalid tube_no: {tube_no}")
+
+        slot, pos = self.tube_to_slotpos[tube_key]
+
+        return self.slotpos_to_pmt_id(slot, pos)
+
+    # ───────────────────────────── #
+    # 4. WCSim → (slot, pos)        #
+    # ───────────────────────────── #
+    
+    def wcsim_to_slotpos(self, tube_no):
+        """
+        tube_no (WCSim) → (slot, pos)
+        """
+        tube_key = int(tube_no) + 1
+
+        if tube_key not in self.tube_to_slotpos:
+            raise ValueError(f"Invalid tube_no: {tube_no}")
+
+        return self.tube_to_slotpos[tube_key]

--- a/notebooks/mpmt_mapping_example.ipynb
+++ b/notebooks/mpmt_mapping_example.ipynb
@@ -1,0 +1,178 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PMT Mapping Usage Examples\n",
+    "\n",
+    "This notebook shows how to use the `PMTMapping` class to convert between different PMT numbering conventions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "# Of course, use your own path to the tools\n",
+    "sys.path.append(os.path.abspath(\"/mnt/netapp2/Store_uni/home/usc/ie/dcr/analysis_tools/analysis_tools\"))\n",
+    "\n",
+    "from wcsim_wcte_coordinate_transformation import PMTMapping"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize mapping\n",
+    "\n",
+    "Replace `geo_path` with your actual geometry file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geo_path = 'your_geometry_file.txt'  # <-- change this\n",
+    "mapping = PMTMapping(geo_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. (slot, pos) → PMT_ID (WCTE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(slot=3, pos=5) -> pmt_id=62\n"
+     ]
+    }
+   ],
+   "source": [
+    "slot = 3\n",
+    "pos = 5\n",
+    "pmt_id = mapping.slotpos_to_pmt_id(slot, pos)\n",
+    "print(f'(slot={slot}, pos={pos}) -> pmt_id={pmt_id}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. PMT_ID (WCTE) → PMT_ID (WCSim)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pmt_id=62 -> wcsim tube_no=917\n"
+     ]
+    }
+   ],
+   "source": [
+    "wcsim_id = mapping.wcte_to_wcsim(pmt_id)\n",
+    "print(f'pmt_id={pmt_id} -> wcsim tube_no={wcsim_id}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. PMT_ID (WCSim) → PMT_ID (WCTE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "wcsim tube_no=917 -> pmt_id=62\n"
+     ]
+    }
+   ],
+   "source": [
+    "pmt_id_back = mapping.wcsim_to_wcte(wcsim_id)\n",
+    "print(f'wcsim tube_no={wcsim_id} -> pmt_id={pmt_id_back}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. PMT_ID (WCSim) → (slot, pos)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "wcsim tube_no=917 -> (slot, pos)=(np.int64(3), np.int64(5))\n"
+     ]
+    }
+   ],
+   "source": [
+    "slot_pos = mapping.wcsim_to_slotpos(wcsim_id)\n",
+    "print(f'wcsim tube_no={wcsim_id} -> (slot, pos)={slot_pos}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e90896f4",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (py39_venv)",
+   "language": "python",
+   "name": "py39_venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Set of functions that allow to transform any slot_id and pos_id into the PMT_id (WCTE convention) and into the tube_id (WCSim convention). Viceversa too.