### PR TITLE
Small modification cleaning up the template event selection process

### DIFF
--- a/analysis_examples/Example Using Data Loader.ipynb
+++ b/analysis_examples/Example Using Data Loader.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 4,
    "id": "498c95dc-184d-44cc-8d1f-5a1322d84c10",
    "metadata": {},
    "outputs": [],
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "id": "4d933f03-68cc-47f1-ba42-a67af7f2fd65",
    "metadata": {},
    "outputs": [],
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "id": "cherenkov_thresholds",
    "metadata": {},
    "outputs": [
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "2f38ae95",
    "metadata": {},
    "outputs": [
@@ -95,6 +95,10 @@
       "Selection : pion\n",
       "  vme_act_eveto          < 7.14 PE  [below threshold]\n",
       "  vme_act_tagger         < 4.44 PE  [below threshold]\n",
+      "  vme_tof_corr           < 21.1 ns  [below threshold]\n",
+      "Selection : tighter_pion_sel\n",
+      "  vme_act_eveto          < 7.14 PE  [below threshold]\n",
+      "  vme_act_tagger         < 3.56 PE  [below threshold]\n",
       "  vme_tof_corr           < 21.1 ns  [below threshold]\n"
      ]
     }
@@ -105,7 +109,7 @@
     "# --- Define your particle selections ---\n",
     "# Every cut is a [variable, operator, value] triplet.\n",
     "# You can apply a cut to any VME variable \n",
-    "# Operators: \">\", \"<\", \">=\", \"<=\", \"between\" (value must be [low, high] for \"between\").\n",
+    "# Operators: \">\", \"<\", \">=\", \"<=\", \"==\", \"!=\", \"between\" (value must be [low, high] for \"between\").\n",
     "# Omit the TOF cut entirely if proton_tof_cut is 0 \n",
     "# This case of TOF separation unavailable happensfor negative polarity and low momentum runs in production 1.0,\n",
     "# To be improved in production 1.1 \n",
@@ -125,7 +129,8 @@
     "# I you want to apply a cut on a new variable, \n",
     "\n",
     "# PIONS: fast particles that do not produce Cherenkov light in either ACT.\n",
-    "pion_sel = BeamSelection.pion(\n",
+    "pion_sel = BeamSelection.selection(\n",
+    "    \"pion\",\n",
     "    [\"vme_act_eveto\",  \"<\", eveto_cut],\n",
     "    [\"vme_act_tagger\", \"<\", tagger_cut],\n",
     "    [\"vme_tof_corr\",        \"<\", tof_cut],\n",
@@ -133,7 +138,8 @@
     "\n",
     "# MUONS: fast particles, below threshold in act_eveto, above threshold in act_tagger,\n",
     "#        with an additional cut on the total muon tagger signal.\n",
-    "muon_sel = BeamSelection.muon(\n",
+    "muon_sel = BeamSelection.selection(\n",
+    "    \"muon\",\n",
     "    [\"vme_act_eveto\",    \"<\", eveto_cut],\n",
     "    [\"vme_act_tagger\",   \">\", tagger_cut],\n",
     "    [\"vme_tof_corr\",          \"<\", tof_cut],\n",
@@ -143,7 +149,8 @@
     ")\n",
     "\n",
     "# ELECTRONS: fast particles above threshold in the upstream ACT (act_eveto).\n",
-    "ele_sel = BeamSelection.electron(\n",
+    "ele_sel = BeamSelection.selection(\n",
+    "    \"electron\",\n",
     "    [\"vme_act_eveto\", \">\", eveto_cut],\n",
     "    [\"vme_tof_corr\",       \"<\", tof_cut],\n",
     "    # You can refine the electron selection with additional cuts on individual ACT PMT signals\n",
@@ -153,11 +160,22 @@
     "\n",
     "# PROTONS: slow particles identified by their TOF falling in a window above the\n",
     "#          fast/slow separation value. Only meaningful when proton_tof_cut > 0.\n",
-    "proton_sel = BeamSelection.proton(\n",
+    "proton_sel = BeamSelection.selection(\n",
+    "    \"proton\",\n",
     "    [\"vme_tof_corr\", \"between\", [tof_cut, tof_cut + 10]],\n",
     ")\n",
     "\n",
-    "pion_sel.describe()"
+    "#Alternatively, you can name your own selection:\n",
+    "tighter_pion_sel = BeamSelection.selection(\n",
+    "    \"tighter_pion_sel\",\n",
+    "    [\"vme_act_eveto\",  \"<\", eveto_cut],\n",
+    "    [\"vme_act_tagger\", \"<\", tagger_cut * 0.8],  # tighter cut on tagger signal\n",
+    "    [\"vme_tof_corr\",        \"<\", tof_cut],\n",
+    "   \n",
+    ")\n",
+    "\n",
+    "pion_sel.describe()\n",
+    "tighter_pion_sel.describe()"
    ]
   },
   {
@@ -355,7 +373,7 @@
    "lastKernelId": null
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/analysis_examples/Example Using Data Loader.ipynb
+++ b/analysis_examples/Example Using Data Loader.ipynb
@@ -165,17 +165,7 @@
     "    [\"vme_tof_corr\", \"between\", [tof_cut, tof_cut + 10]],\n",
     ")\n",
     "\n",
-    "#Alternatively, you can name your own selection:\n",
-    "tighter_pion_sel = BeamSelection.selection(\n",
-    "    \"tighter_pion_sel\",\n",
-    "    [\"vme_act_eveto\",  \"<\", eveto_cut],\n",
-    "    [\"vme_act_tagger\", \"<\", tagger_cut * 0.8],  # tighter cut on tagger signal\n",
-    "    [\"vme_tof_corr\",        \"<\", tof_cut],\n",
-    "   \n",
-    ")\n",
-    "\n",
-    "pion_sel.describe()\n",
-    "tighter_pion_sel.describe()"
+    "pion_sel.describe()\n"
    ]
   },
   {

--- a/analysis_tools/beam_selection.py
+++ b/analysis_tools/beam_selection.py
@@ -45,6 +45,14 @@ class Cut:
     @staticmethod
     def between(low, high):
         return lambda x: (x > low) & (x < high)
+    
+    @staticmethod
+    def equal_to(value):
+        return lambda x: x == value
+    
+    @staticmethod
+    def not_equal_to(value):
+        return lambda x: x != value
 
     @staticmethod
     def true():
@@ -140,92 +148,47 @@ class BeamSelection:
     # ------------------------------------------------------------------
 
     @classmethod
-    def electron(cls, *cuts):
+    def selection(cls, name, *cuts):
         """
-        Electrons: fast particles above threshold in the upstream ACT (act_eveto).
+        Custom selection: to be named by the user and defined by arbitrary cuts.
         Pass all cuts as [variable, operator, value] triplets.
+        ---------------------------------------------------------------------------
+        Electrons: fast particles above threshold in the upstream ACT (act_eveto).
 
         Typical cuts
         ------------
         ["act_eveto", ">", act_eveto_cut]
         ["tof",       "<", proton_tof_cut]   # omit if TOF info is unavailable
-        """
-        sel = cls("electron")
-        for spec in cuts:
-            sel.add(_parse_cut_spec(spec))
-        return sel
-
-    @classmethod
-    def muon(cls, *cuts):
-        """
-        Muons: fast particles, below threshold in the upstream ACT (act_eveto)
+        ---------------------------------------------------------------------------
+        Muons (or muons at higher momenta in kaon runs): fast particles, below threshold in the upstream ACT (act_eveto)
         and above threshold in the downstream ACT (act_tagger).
-        Pass all cuts as [variable, operator, value] triplets.
-
+        
         Typical cuts
         ------------
         ["act_eveto",    "<", act_eveto_cut]
         ["act_tagger",   ">", act_tagger_cut]
         ["tof",          "<", proton_tof_cut]   # omit if TOF info is unavailable
         ["mu_tag_total", ">", mu_tag_cut]        # optional extra cut
-        """
-        sel = cls("muon")
-        for spec in cuts:
-            sel.add(_parse_cut_spec(spec))
-        return sel
-
-    @classmethod
-    def kaon(cls, *cuts):
-        """
-        Kaons: fast particles, below threshold in the upstream ACT (act_eveto)
-        and above threshold in the downstream ACT (act_tagger).
-        Pass all cuts as [variable, operator, value] triplets.
-
-        Typical cuts
-        ------------
-        ["act_eveto",  "<", act_eveto_cut]
-        ["act_tagger", ">", act_tagger_cut]
-        ["tof",        "<", proton_tof_cut]   # omit if TOF info is unavailable
-        """
-        sel = cls("kaon")
-        for spec in cuts:
-            sel.add(_parse_cut_spec(spec))
-        return sel
-
-    @classmethod
-    def pion(cls, *cuts):
-        """
-        Pions: fast particles below threshold in both ACTs.
-        Pass all cuts as [variable, operator, value] triplets.
-
+        ---------------------------------------------------------------------------
+        Pions: fast particles below threshold in both ACTs. 
         Typical cuts
         ------------
         ["act_eveto",  "<", act_eveto_cut]
         ["act_tagger", "<", act_tagger_cut]
         ["tof",        "<", proton_tof_cut]   # omit if TOF info is unavailable
-        """
-        sel = cls("pion")
-        for spec in cuts:
-            sel.add(_parse_cut_spec(spec))
-        return sel
-
-    @classmethod
-    def proton(cls, *cuts):
-        """
-        Protons: slow particles identified by their TOF falling in a window above
-        the fast/slow separation value.
-        Pass all cuts as [variable, operator, value] triplets.
-
+        ---------------------------------------------------------------------------
+        protons: slow particles identified by their TOF falling in a window above the fast/slow separation value.
         Typical cuts
         ------------
         ["tof", "between", [proton_tof_cut, proton_tof_cut + window]]
+
         """
-        sel = cls("proton")
+        sel = cls(name)
         for spec in cuts:
             sel.add(_parse_cut_spec(spec))
         return sel
 
-
+    
 
 def _parse_cut_spec(spec):
     """
@@ -254,6 +217,10 @@ def _parse_cut_spec(spec):
         func, direction = Cut.greater_than(value), "above"
     elif op == "<":
         func, direction = Cut.less_than(value), "below"
+    elif op == "==":
+        func, direction = Cut.equal_to(value), "equal"
+    elif op == "!=":
+        func, direction = Cut.not_equal_to(value), "not_equal"
     elif op == ">=":
         func, direction = (lambda v: lambda x: x >= v)(value), "above"
     elif op == "<=":
@@ -275,6 +242,7 @@ _VARIABLE_ALIASES = {
     "tof":          "vme_tof_corr",
     "mu_tag_total": "vme_mu_tag_total",
     "act_0_charge": "vme_act0_l_charge",
+    "T5_particle_nr": "T5_particle_nr",
 
 }
 
@@ -328,7 +296,8 @@ _VARIABLE_UNITS = {
     'vme_tof_t0t5': "ns",
     'vme_tof_t1t5': "ns",
     'vme_mu_tag_l_charge': "a.u.",
-    'vme_mu_tag_r_charge': "a.u."
+    'vme_mu_tag_r_charge': "a.u.",
+    'T5_particle_nr': " ",
 }
 
 


### PR DESCRIPTION
Previously we had a selection for each particle type, now we simply create a selection and call it as desired (more compact).

Also implemented the "==" and "!=" selection options which are useful for selections (e.g. T5_event_nr) 